### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "categories": ["export", "images"],
   "description": "Download images from project or dataset.",
   "docker_image": "supervisely/import-export:6.73.564",
-  "min_instance_version": "6.15.2",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://github.com/supervisely-ecosystem/download-images/assets/119248312/7fc6f17a-4afb-4521-9c13-59e95aab402c",

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["export", "images"],
   "description": "Download images from project or dataset.",
-  "docker_image": "supervisely/import-export:6.73.466",
+  "docker_image": "supervisely/import-export:6.73.564",
   "min_instance_version": "6.15.2",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.73.256
+supervisely==6.73.564
 
 # code formatter
 black


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
